### PR TITLE
Use v4 for artifacts actions

### DIFF
--- a/.github/workflows/build-tool.yml
+++ b/.github/workflows/build-tool.yml
@@ -48,7 +48,7 @@ jobs:
         run: ./Build.ps1 -Build -Pack
 
       - name: Upload package artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: packages
           path: artifacts/Packages/

--- a/.github/workflows/documentation-tool.yml
+++ b/.github/workflows/documentation-tool.yml
@@ -38,7 +38,7 @@ jobs:
         run: ./Build.ps1 -GenerateDocs
 
       - name: Upload documentation results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: documentation
           path: artifacts/Documentation/

--- a/.github/workflows/integrationtest-tool.yml
+++ b/.github/workflows/integrationtest-tool.yml
@@ -51,7 +51,7 @@ jobs:
         run: ./Build.ps1 -IntegrationTests
 
       - name: Upload test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{inputs.REPOSITORY_NAME}}-test-results
           path: artifacts/Tests/

--- a/.github/workflows/publish-test-coverage-tool.yml
+++ b/.github/workflows/publish-test-coverage-tool.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download coverage results
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: ${{inputs.REPOSITORY_NAME}}-coverage-results
           path: artifacts/coverage-results

--- a/.github/workflows/publish-tool.yml
+++ b/.github/workflows/publish-tool.yml
@@ -40,7 +40,7 @@ jobs:
           dotnet-version: ${{ inputs.dotnet_sdk_version }}
 
       - name: Download package artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: packages
           path: artifacts/Packages/

--- a/.github/workflows/reportgenerator-tool.yml
+++ b/.github/workflows/reportgenerator-tool.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v2
       
       - name: Download test results
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: ${{inputs.REPOSITORY_NAME}}-test-results
           path: artifacts/test-results
@@ -42,7 +42,7 @@ jobs:
           reporttypes: Html
           
       - name: Upload test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{inputs.REPOSITORY_NAME}}-coverage-results
           path: Coverage/

--- a/.github/workflows/unittest-tool.yml
+++ b/.github/workflows/unittest-tool.yml
@@ -56,7 +56,7 @@ jobs:
         run: dotnet test --collect:"XPlat Code Coverage"
 
       - name: Upload test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ${{inputs.REPOSITORY_NAME}}-test-results
           path: src\Tests\**\TestResults\**\coverage.cobertura.xml


### PR DESCRIPTION
Older versions are deprecated and let pipelines fail.

(cherry picked from commit bdf704cbca645e439771f82d6a3ad44df4dd52c7)